### PR TITLE
[SCOPE-002] Extend the cube to group by sets with region code

### DIFF
--- a/ganymede/macros/raw_region_to_province.sql
+++ b/ganymede/macros/raw_region_to_province.sql
@@ -1,0 +1,18 @@
+{% macro raw_region_to_province(column_name) %}
+    case
+        when {{column_name}} in ('Manitoba') then 'MB'
+        when {{column_name}} in ('British Columbia', 'Colombie-Britannique') then 'BC'
+        when {{column_name}} in ('Nouvelle-Écosse', 'Nova Scotia') then 'NS'
+        when {{column_name}} in ('Île-du-Prince-Édouard', 'Prince Edward Island') then 'PE'
+        when {{column_name}} in ('Terre-Neuve et Labr.', 'Newfoundland and Labrador') then 'NL'
+        when {{column_name}} in ('Terr. du Nord-Ouest', 'Northwest Territories') then 'NT'
+        when {{column_name}} in ('Alberta') then 'AB'
+        when {{column_name}} in ('ON', 'Ontario') then 'ON'
+        when {{column_name}} in ('Nouveau-Brunswick', 'New Brunswick') then 'NB'
+        when {{column_name}} in ('Quebec', 'Québec') then 'QC'
+        when {{column_name}} in ('Yukon') then 'YT'
+        when {{column_name}} in ('Saskatchewan') then 'SK'
+        when {{column_name}} in ('Nunavut') then 'NU'
+        else 'Unknown'
+    end
+{% endmacro %}

--- a/ganymede/models/wolfram/product_timeseries_metrics.sql
+++ b/ganymede/models/wolfram/product_timeseries_metrics.sql
@@ -9,6 +9,7 @@ with all_calendar_dates as (
 )
 select
     acd.val as calendar_date
+    , {{ raw_region_to_province("s.store_address->>'addressRegion'")}} as region_code
     , plh.product_id
     , plh.currency
     , plh.unit
@@ -17,4 +18,11 @@ select
 from all_calendar_dates acd
 left join {{ source('aethervest', 'product_listings_history') }} plh
   on acd.val > plh.effective_from and acd.val <= coalesce(plh.effective_to, '9999-01-01'::timestamp)
-group by 1, 2, 3, 4
+join {{ source('aethervest', 'stores')}} s
+  on plh.store_id = s.id
+group by
+  grouping sets (
+    (1,2,3,4,5)
+    ,(1,3,4,5)
+  )
+

--- a/ganymede/models/wolfram/wolfram.yml
+++ b/ganymede/models/wolfram/wolfram.yml
@@ -8,3 +8,12 @@ models:
       injected into the group by statement.
     columns:
       - name: calendar_date
+      - name: region_code
+        description: |
+          The two letter international standard denomination for the country's subdivisions established by the ISO-3166-2 code.
+          This can be a province, territory, state etc. Uses `raw_region_to_province` macro for parsing of the raw region code.
+          If this accepted values test breaks, it means that there was a new region code detected and the logic should be updated
+          to handle the new values if possible.
+        tests:
+          - accepted_values:
+              values: ['NL', 'PE', 'NS', 'NB', 'NB', 'QC', 'ON', 'MB', 'SK', 'AB', 'BC', 'YT', 'NT', 'NU']


### PR DESCRIPTION
What: This adds the region code as a column and uses it for the grouping set aggregations.

Why: The meets the requires of the API spec highlighted in tm41m.io and also discussed in the 1-pager the first news application.

Tests - 
```
18:56:18  Running with dbt=1.5.2
18:56:18  Registered adapter: postgres=1.5.2
18:56:19  Found 1 model, 1 test, 0 snapshots, 0 analyses, 308 macros, 0 operations, 0 seed files, 5 sources, 0 exposures, 0 metrics, 0 groups
18:56:19
18:56:21  Concurrency: 1 threads (target='prod')
18:56:21
18:56:21  1 of 1 START sql view model wolfram.product_timeseries_metrics ................. [RUN]
18:56:22  1 of 1 OK created sql view model wolfram.product_timeseries_metrics ............ [CREATE VIEW in 1.02s]
18:56:23  
18:56:23  Finished running 1 view model in 0 hours 0 minutes and 4.04 seconds (4.04s).
18:56:23  
18:56:23  Completed successfully

18:56:27  Registered adapter: postgres=1.5.2
18:56:27  Found 1 model, 1 test, 0 snapshots, 0 analyses, 308 macros, 0 operations, 0 seed files, 5 sources, 0 exposures, 0 metrics, 0 groups
18:56:27
18:56:29  Concurrency: 1 threads (target='prod')
18:56:29
18:56:29  1 of 1 START test accepted_values_product_timeseries_metrics_region_code__NL__PE__NS__NB__NB__QC__ON__MB__SK__AB__BC__YT__NT__NU  [RUN]
18:56:30  1 of 1 PASS accepted_values_product_timeseries_metrics_region_code__NL__PE__NS__NB__NB__QC__ON__MB__SK__AB__BC__YT__NT__NU  [PASS in 1.11s]
18:56:30  
18:56:30  Finished running 1 test in 0 hours 0 minutes and 3.35 seconds (3.35s).
18:56:30
18:56:30  Completed successfully
18:56:30
18:56:30  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```