### PR TITLE
Drop the dbname qualifer for sources

### DIFF
--- a/ganymede/models/sources.yml
+++ b/ganymede/models/sources.yml
@@ -2,7 +2,6 @@ version: 2
 
 sources:
   - name: aethervest
-    database: scopuli_prod
     schema: aethervest_src  
     tables:
       - name: products


### PR DESCRIPTION
What: This drops the dbname qualifier in the source yml file.

Why: After defining local targets i.e. `scopuli_mmei`, this created issues with cross db references i.e.

```
 dbt run -m product_timeseries_metrics
17:02:00  Running with dbt=1.5.2
17:02:00  Registered adapter: postgres=1.5.2
17:02:01  Found 2 models, 1 test, 0 snapshots, 0 analyses, 309 macros, 0 operations, 0 seed files, 6 sources, 0 exposures, 0 metrics, 0 groups
17:02:01
17:02:29  Concurrency: 1 threads (target='local')
17:02:29
17:02:29  1 of 1 START sql view model wolfram.product_timeseries_metrics ................. [RUN]
17:02:35  1 of 1 ERROR creating sql view model wolfram.product_timeseries_metrics ........ [ERROR in 5.78s]
17:02:41  
17:02:41  Finished running 1 view model in 0 hours 0 minutes and 40.25 seconds (40.25s).
17:02:41
17:02:41  Completed with 1 error and 0 warnings:
17:02:41
17:02:41  Database Error in model product_timeseries_metrics (models/wolfram/product_timeseries_metrics.sql)
17:02:41    cross-database references are not implemented: "scopuli_prod.aethervest_src.product_listings_history"
17:02:41    LINE 46:   left join "scopuli_prod"."aethervest_src"."product_listing...
17:02:41                         ^
17:02:41    compiled Code at target/run/ganymede/models/wolfram/product_timeseries_metrics.sql
17:02:41
17:02:41  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```

Dropping the dbname allows the compiles to default to the local dev dbname. See that these runs succeed now - 

```
dbt run -m product_timeseries_metrics
17:15:10  Running with dbt=1.5.2
17:15:10  Registered adapter: postgres=1.5.2
17:15:10  Found 2 models, 1 test, 0 snapshots, 0 analyses, 310 macros, 0 operations, 0 seed files, 6 sources, 0 exposures, 0 metrics, 0 groups
17:15:10
17:15:33  Concurrency: 1 threads (target='local')
17:15:33
17:15:33  1 of 1 START sql view model wolfram.product_timeseries_metrics ................. [RUN]
17:15:39  1 of 1 OK created sql view model wolfram.product_timeseries_metrics ............ [CREATE VIEW in 6.04s]
17:15:45  
17:15:45  Finished running 1 view model in 0 hours 0 minutes and 34.60 seconds (34.60s).
17:15:45
17:15:45  Completed successfully
17:15:45
17:15:45  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```