### PR TITLE
Add step for updating cron schedule dbt job definitions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ jobs:
             echo "export SCOPULI_ENV=${SCOPULI_ENV}" >> .env
             echo "export SCOPULI_RUNNER_DIR=${SCOPULI_RUNNER_DIR}" >> .env
             << parameters.scp >> .env $SCOPULI_RUNNER_SSH_USER@$SCOPULI_RUNNER_SSH_HOST:/home/circleci/.env
+      - run:
+          name: Update the cron schedule with dbt job definitions
+          command: |
+            << parameters.ssh >> "bash $SCOPULI_RUNNER_DIR/scopuli/scheduler/schedule.sh"
 
 workflows:
   deploy-to-prod:


### PR DESCRIPTION
What: This updates the circleci config with an additional step to update the cron schedules with job definitons.

Tested this by going into the box and running the script i.e.

```
circleci@job-runner-prod:~$ bash /home/circleci/scopuli/scheduler/schedule.sh 
circleci@job-runner-prod:~$ crontab -l
0 0 */2 * * docker run --env-file /home/circleci/.env --network=host --mount type=bind,source=/home/circleci/scopuli/ganymede/,target=/usr/app --mount 
type=bind,source=/home/circleci/scopuli/,target=/root/.dbt/ ghcr.io/dbt-labs/dbt-postgres:1.5.2 run --target prod
```