### PR TITLE
Handle creds for loading census divisions as part of shell script

### DIFF
--- a/scripts/load_census_divisions.sh
+++ b/scripts/load_census_divisions.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-psql -h $PG_HOST -p $PG_PORT -d $PG_DBNAME -U $PG_USERNAME < migrations/20231010_importpostgis_0000.up.sql
+PGHOST=$SCOPULI_PGHOST
+PGPORT=$SCOPULI_PGPORT
+PGDBNAME=$SCOPULI_PGDBNAME
+PGUSERNAME=$SCOPULI_PGUSERNAME
+
+psql -h $PGHOST -p $PGPORT -d $PGDBNAME -U $PGUSERNAME < migrations/20231010_importpostgis_0000.up.sql
 
 cd_filename=tmp_lcd_000b21a_e.zip
 
@@ -9,4 +14,4 @@ curl -o $cd_filename https://www12.statcan.gc.ca/census-recensement/2021/geo/sip
 unzip $cd_filename -d tmp/
 rm -f $cd_filename
 
-shp2pgsql -D -I -s 3347 tmp/lcd_000b21a_e.shp static.statcan_census_divisions | psql -h $PG_HOST -p $PG_PORT -d $PG_DBNAME -U $PG_USERNAME
+shp2pgsql -D -I -s 3347 tmp/lcd_000b21a_e.shp static.statcan_census_divisions | psql -h $PGHOST -p $PGPORT -d $PGDBNAME -U $PGUSERNAME


### PR DESCRIPTION
This handles the creds from `env` a bit better and requires explicit `password` so user is aware of the implications.